### PR TITLE
Fix : refresh토큰 페이로드에 잘못된 값 입력된 것 수정

### DIFF
--- a/src/domain/app/app.module.ts
+++ b/src/domain/app/app.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { AdminModule } from '../admin/admin.module';
 import { AuthModule } from '../auth/auth.module';

--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -104,7 +104,9 @@ export class AuthController {
       sameSite: true,
     });
 
-    const accessToken: string = this.authService.accessTokenInssuance(user.id);
+    const accessToken: string = this.authService.accessTokenInssuance(
+      user.userId,
+    );
     // 발급된 accessToken 클라이언트에 전달
     return res.redirect(
       `${process.env.CLIENT_REDIRECT_PAGE}?access_token=${accessToken}`,

--- a/src/domain/auth/strategy/jwt-strategy.ts
+++ b/src/domain/auth/strategy/jwt-strategy.ts
@@ -13,6 +13,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { name: payload.name, userId: payload.userId };
+    return { userId: payload.userId };
   }
 }


### PR DESCRIPTION

## Motivation

#11 


auth Controller에서 잘못된 값으로 엑세스토큰을 발급하고 있었습니다.
- guard에서 세팅해준 user값에 userId가 있는데. user.userId값으로 발급한게 아닌 user.id로 발급되어, 다른 id값이 토큰에 저장되고있는 부분을 수정했습니다.



