### PR TITLE
feat: 유저 탈퇴 기능 구현

### DIFF
--- a/src/domain/favorite/favorite.service.ts
+++ b/src/domain/favorite/favorite.service.ts
@@ -76,4 +76,8 @@ export class FavoriteService {
 
     return { statuesCode: 200, message: `remove 성공`, cafeId };
   }
+
+  async unRegisterFavorite(userId: string) {
+    await this.favoriteModel.deleteOne({ userId }).exec();
+  }
 }

--- a/src/domain/user/user.controller.ts
+++ b/src/domain/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, Req, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guard/jwt-guard';
 import { UserService } from './user.service';
 
@@ -10,5 +10,11 @@ export class UserController {
   @UseGuards(JwtAuthGuard)
   async userData(@Req() req) {
     return await this.userService.findOne({ userId: req.user.userId });
+  }
+
+  @Delete('')
+  @UseGuards(JwtAuthGuard)
+  async deleteUser(@Req() req) {
+    return await this.userService.unRegister(req.user.userId);
   }
 }

--- a/src/domain/user/user.repository.ts
+++ b/src/domain/user/user.repository.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { randomUUID } from 'crypto';
 import { Model } from 'mongoose';
@@ -24,5 +24,11 @@ export class UserRepository {
       { userId },
       { $set: { ...updateDetails } },
     );
+  }
+  async deleteOne(userId: string) {
+    const deleteResult = await this.userModel.deleteOne({ userId }, {});
+    if (deleteResult.deletedCount === 0) {
+      throw new HttpException('유저 정보가 없습니다.', HttpStatus.BAD_REQUEST);
+    }
   }
 }

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { UserDetailDto } from './dto/user.dto';
 import { UserRepository } from './user.repository';
+import { FavoriteService } from '../favorite/favorite.service';
 
 @Injectable()
 export class UserService {
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly favoriteService: FavoriteService,
+  ) {}
 
   async findOne(options) {
     return await this.userRepository.findOne(options);
@@ -24,5 +28,11 @@ export class UserService {
         refreshTokenIv,
       }),
     );
+  }
+
+  async unRegister(userId: string) {
+    await this.favoriteService.unRegisterFavorite(userId);
+    await this.userRepository.deleteOne(userId);
+    return { statusCode: 200, message: '회원탈퇴 성공', userId };
   }
 }


### PR DESCRIPTION
## Motivation

유저 탈퇴기능을 구현했습니다. 
파라미터나 쿼리를 따로 보내주지 않아도 accessToken 안의 userId를 파싱해서 해당 유저의 user정보와 즐겨찾기 db를 삭제합니다.


<br>

## Key Changes



### 스크린샷

<br>

## To Reviewers

