### PR TITLE
Feat: 모바일, 웹 환경 구분 액세스토큰 리다이렉트 구현 

### DIFF
--- a/.github/workflows/Delivery.yaml
+++ b/.github/workflows/Delivery.yaml
@@ -54,13 +54,14 @@ jobs:
           chmod 600 ~/.ssh/hipspot_server.pem
           echo "스크립트 생성"
           cat > deploy.sh << 'EOF'
+          source ~/.zshrc;
           cd ~/$(echo "${{github.repository}}" | awk -F '/' '{print $2}');
           pwd;
           git checkout ${{ github.event.pull_request.head.ref }};
-          git pull;
+          git pull origin ${{ github.event.pull_request.head.ref }};
           pnpm i;
           pnpm build;
-          pm2 stop prod-server;
+          pm2 delete prod-server;
           pm2 start pnpm --name prod-server -- start:prod;
           EOF
           echo "스크립트 전송"

--- a/.github/workflows/Delivery.yaml
+++ b/.github/workflows/Delivery.yaml
@@ -53,9 +53,8 @@ jobs:
           echo "${{ secrets.EC2_REMOTE_SSH_KEY  }}" > ~/.ssh/hipspot_server.pem
           chmod 600 ~/.ssh/hipspot_server.pem
           echo "스크립트 생성"
-          REPO_NAME=$(echo "${{github.repository}}" | awk -F '/' '{print $2}')
           cat > deploy.sh << 'EOF'
-          cd ~/${REPO_NAME};
+          cd ~/$(echo "${{github.repository}}" | awk -F '/' '{print $2}');
           pwd;
           git checkout ${{ github.event.pull_request.head.ref }};
           git pull;

--- a/.github/workflows/Delivery.yaml
+++ b/.github/workflows/Delivery.yaml
@@ -17,6 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
       - name: 노드 ${{ matrix.node-version }}버젼으로 실행
         uses: actions/setup-node@v3
         with:
@@ -33,9 +36,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: 브랜치 확인 및 컨텍스트 확인
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          runs: |
+            echo " 브랜치 확인, ${{ github.event.pull_request.head.ref }}"
+            echo " 컨텍스트 확인 , ${{ github }}"
       - name: 노드 ${{ matrix.node-version }} 버젼으로 실행
         uses: actions/setup-node@v3
         with:
@@ -45,5 +52,19 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.EC2_REMOTE_SSH_KEY  }}" > ~/.ssh/hipspot_server.pem
           chmod 600 ~/.ssh/hipspot_server.pem
-          ssh -i "~/.ssh/hipspot_server.pem" -o StrictHostKeyChecking=no ${{secrets.EC2_USER}}@${{secrets.EC2_KNOWN_HOST}} "zsh ~/deploy.sh" 
+          echo "스크립트 생성"
+          REPO_NAME=$(echo "${{github.repository}}" | awk -F '/' '{print $2}')
+          cat > deploy.sh << 'EOF'
+          cd ${REPO_NAME};
+          git checkout ${{ github.event.pull_request.head.ref }};
+          git pull;
+          pnpm i;
+          pnpm build;
+          pm2 stop prod-server;
+          pm2 start pnpm --name prod-server -- start:prod;
+          EOF
+          echo "스크립트 전송"
+          scp -i "~/.ssh/hipspot_server.pem" -o StrictHostKeyChecking=no deploy.sh ${{secrets.EC2_USER}}@${{secrets.EC2_KNOWN_HOST}}:~/deploy.sh
+          echo "스크립트 실행"
+          ssh -i "~/.ssh/hipspot_server.pem" -o StrictHostKeyChecking=no ${{secrets.EC2_USER}}@${{secrets.EC2_KNOWN_HOST}} "zsh ~/deploy.sh; rm -rf ~/deploy.sh" 
           rm -f ~/.ssh/hipspot_server.pem

--- a/.github/workflows/Delivery.yaml
+++ b/.github/workflows/Delivery.yaml
@@ -56,6 +56,7 @@ jobs:
           REPO_NAME=$(echo "${{github.repository}}" | awk -F '/' '{print $2}')
           cat > deploy.sh << 'EOF'
           cd ${REPO_NAME};
+          pwd;
           git checkout ${{ github.event.pull_request.head.ref }};
           git pull;
           pnpm i;

--- a/.github/workflows/Delivery.yaml
+++ b/.github/workflows/Delivery.yaml
@@ -55,7 +55,7 @@ jobs:
           echo "스크립트 생성"
           REPO_NAME=$(echo "${{github.repository}}" | awk -F '/' '{print $2}')
           cat > deploy.sh << 'EOF'
-          cd ${REPO_NAME};
+          cd ~/${REPO_NAME};
           pwd;
           git checkout ${{ github.event.pull_request.head.ref }};
           git pull;

--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
 
     strategy:
       matrix:

--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -113,7 +113,7 @@ export class AuthController {
   async handleRedirect(
     @Req() req: Request,
     @Res() res: Response,
-    @Query('platform') platform: string,
+    @Query('state') platform: string,
   ) {
     const { email, photo, displayName } =
       req.user as ParsedGoogltAuthProfileType;

--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -65,15 +65,10 @@ export class AuthController {
     const refreshToken = await this.authService.refreshTokenInssuance(
       user.userId,
     );
-    res.cookie('hipspot_refresh_token', refreshToken, {
-      httpOnly: true,
-      sameSite: true,
-    });
-
     const accessToken: string = this.authService.accessTokenInssuance(user.id);
 
     if (state === 'mobile') {
-      const url = `hipspot-mobile://?access_token=${accessToken}`;
+      const url = `hipspot-mobile://?access_token=${accessToken}&refresh_token=${refreshToken}`;
       res.setHeader('Content-Type', 'text/html');
       res.send(`
           <!doctype html>
@@ -96,6 +91,10 @@ export class AuthController {
 
     // 플랫폼 web인 경우 access토큰 파싱 가능한 url로 리다이렉트
     if (state === 'web') {
+      res.cookie('hipspot_refresh_token', refreshToken, {
+        httpOnly: true,
+        sameSite: true,
+      });
       return res.redirect(
         `${process.env.WEB_REDIRECT_PAGE}?access_token=${accessToken}`,
       );
@@ -130,10 +129,6 @@ export class AuthController {
     const refreshToken = await this.authService.refreshTokenInssuance(
       user.userId,
     );
-    res.cookie('hipspot_refresh_token', refreshToken, {
-      httpOnly: true,
-      sameSite: true,
-    });
 
     // 발급된 accessToken 클라이언트에 전달
     const accessToken: string = this.authService.accessTokenInssuance(
@@ -143,7 +138,7 @@ export class AuthController {
     // 플랫폼아 모바일인 경우, schema 변경후 브라우저에서 해당 location으로 이동하는 JS 코드가 담긴 Html 전달
     // setTimeout으로 자동 실행
     if (platform === 'mobile') {
-      const url = `hipspot-mobile://?access_token=${accessToken}`;
+      const url = `hipspot-mobile://?access_token=${accessToken}&refresh_token=${refreshToken}`;
       res.setHeader('Content-Type', 'text/html');
       res.send(`
           <!doctype html>
@@ -166,6 +161,10 @@ export class AuthController {
 
     // 플랫폼 web인 경우 access토큰 파싱 가능한 url로 리다이렉트
     if (platform === 'web') {
+      res.cookie('hipspot_refresh_token', refreshToken, {
+        httpOnly: true,
+        sameSite: true,
+      });
       return res.redirect(
         `${process.env.WEB_REDIRECT_PAGE}?access_token=${accessToken}`,
       );

--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -6,7 +6,9 @@ import {
   HttpStatus,
   Inject,
   Logger,
+  Param,
   Post,
+  Query,
   Req,
   Res,
   UseGuards,
@@ -21,7 +23,7 @@ import { GoogleAuthGuard } from './guard/google-auth-guard';
 @Controller('auth')
 export class AuthController {
   constructor(
-    @Inject('AUTH_SERVICE') private readonly authService: AuthService,
+    private readonly authService: AuthService,
     private readonly jwtService: JwtService,
     private readonly logger: Logger,
   ) {}
@@ -78,7 +80,11 @@ export class AuthController {
   //google AuthGuard에서 확인 이후 이 컨트롤러로 user정보 전달
   @Get('callback')
   @UseGuards(GoogleAuthGuard)
-  async handleRedirect(@Req() req: Request, @Res() res: Response) {
+  async handleRedirect(
+    @Req() req: Request,
+    @Res() res: Response,
+    @Query('platform') platform: string,
+  ) {
     const { email, photo, displayName } =
       req.user as ParsedGoogltAuthProfileType;
     const inboundedUser = {
@@ -104,13 +110,41 @@ export class AuthController {
       sameSite: true,
     });
 
+    // 발급된 accessToken 클라이언트에 전달
     const accessToken: string = this.authService.accessTokenInssuance(
       user.userId,
     );
-    // 발급된 accessToken 클라이언트에 전달
-    return res.redirect(
-      `${process.env.CLIENT_REDIRECT_PAGE}?access_token=${accessToken}`,
-    );
+
+    // 플랫폼아 모바일인 경우, schema 변경후 브라우저에서 해당 location으로 이동하는 JS 코드가 담긴 Html 전달
+    // setTimeout으로 자동 실행
+    if (platform === 'mobile') {
+      const url = `hipspot-mobile://?access_token=${accessToken}`;
+      res.setHeader('Content-Type', 'text/html');
+      res.send(`
+          <!doctype html>
+          <html>
+            <head>
+              <title>Redirecting...</title>
+              <script>
+                setTimeout(function() {
+                  window.location = '${url}';
+                }, 100);
+              </script>
+            </head>
+            <body>
+             <a href="${url}">${url}> 버튼 눌러서 로그인하기 </a>
+            </body>
+          </html>
+        `);
+      return;
+    }
+
+    // 플랫폼 web인 경우 access토큰 파싱 가능한 url로 리다이렉트
+    if (platform === 'web') {
+      return res.redirect(
+        `${process.env.WEB_REDIRECT_PAGE}?access_token=${accessToken}`,
+      );
+    }
   }
 
   /**

--- a/src/domain/auth/auth.module.ts
+++ b/src/domain/auth/auth.module.ts
@@ -15,13 +15,7 @@ import { JwtStrategy } from './strategy/jwt-strategy';
     MongooseModule.forFeature([{ name: User.name, schema: userSchema }]),
     JwtModule,
   ],
-  providers: [
-    { provide: 'AUTH_SERVICE', useClass: AuthService },
-    GoogleStrategy,
-    AppleStrategy,
-    JwtStrategy,
-    Logger,
-  ],
+  providers: [AuthService, GoogleStrategy, AppleStrategy, JwtStrategy, Logger],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/src/domain/auth/guard/google-auth-guard.ts
+++ b/src/domain/auth/guard/google-auth-guard.ts
@@ -4,6 +4,9 @@ import { AuthGuard } from '@nestjs/passport';
 @Injectable()
 export class GoogleAuthGuard extends AuthGuard('google') {
   async canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest();
+    console.log('guard, activate', req.url);
+
     const activate = (await super.canActivate(context)) as boolean;
     return activate;
   }

--- a/src/domain/auth/strategy/apple.strategy.ts
+++ b/src/domain/auth/strategy/apple.strategy.ts
@@ -8,7 +8,6 @@ export class AppleStrategy extends PassportStrategy(Strategy, 'apple') {
       keyID: process.env.APPLE_OAUTH_KEY_ID,
       callbackURL: process.env.APPLE_OAUTH_CALLBACK_URL,
       keyFilePath: process.env.APPLE_OAUTH_PRIVATE_KEY_PATH,
-      passReqToCallback: true,
       scope: ['email', 'name'],
     });
   }

--- a/src/domain/auth/strategy/apple.strategy.ts
+++ b/src/domain/auth/strategy/apple.strategy.ts
@@ -18,7 +18,7 @@ export class AppleStrategy extends PassportStrategy(Strategy, 'apple') {
     console.log('apple authenticate', req.url, 'platform', platform);
     super.authenticate(req, {
       ...options,
-      state: { platform }, // 콜백으로 받는 url에 state 쿼리 추가
+      state: platform, // 콜백으로 받는 url에 state 쿼리 추가
     });
   }
 }

--- a/src/domain/auth/strategy/apple.strategy.ts
+++ b/src/domain/auth/strategy/apple.strategy.ts
@@ -18,7 +18,7 @@ export class AppleStrategy extends PassportStrategy(Strategy, 'apple') {
     console.log('apple authenticate', req.url, 'platform', platform);
     super.authenticate(req, {
       ...options,
-      callbackURL: `${process.env.GOOGLE_OAUTH_CALLBACK_URI}?platform=${platform}`, // authenticate 오버라이딩으로 동적 Url 적용
+      callbackURL: `${process.env.APPLE_OAUTH_CALLBACK_URL}?platform=${platform}`, // authenticate 오버라이딩으로 동적 Url 적용
     });
   }
 }

--- a/src/domain/auth/strategy/apple.strategy.ts
+++ b/src/domain/auth/strategy/apple.strategy.ts
@@ -7,7 +7,7 @@ export class AppleStrategy extends PassportStrategy(Strategy, 'apple') {
       clientID: process.env.APPLE_OAUTH_CLIENT_ID,
       teamID: process.env.APPLE_OAUTH_TEAM_ID,
       keyID: process.env.APPLE_OAUTH_KEY_ID,
-      // callbackURL: process.env.APPLE_OAUTH_CALLBACK_URL,
+      callbackURL: process.env.APPLE_OAUTH_CALLBACK_URL,
       keyFilePath: process.env.APPLE_OAUTH_PRIVATE_KEY_PATH,
       scope: ['email', 'name'],
     });
@@ -18,7 +18,7 @@ export class AppleStrategy extends PassportStrategy(Strategy, 'apple') {
     console.log('apple authenticate', req.url, 'platform', platform);
     super.authenticate(req, {
       ...options,
-      callbackURL: `${process.env.APPLE_OAUTH_CALLBACK_URL}?platform=${platform}`, // authenticate 오버라이딩으로 동적 Url 적용
+      state: { platform }, // 콜백으로 받는 url에 state 쿼리 추가
     });
   }
 }

--- a/src/domain/auth/strategy/apple.strategy.ts
+++ b/src/domain/auth/strategy/apple.strategy.ts
@@ -1,14 +1,24 @@
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from '@arendajaelu/nestjs-passport-apple';
+import { parseQueries } from 'src/libs/utils/helper/parseQuery';
 export class AppleStrategy extends PassportStrategy(Strategy, 'apple') {
   constructor() {
     super({
       clientID: process.env.APPLE_OAUTH_CLIENT_ID,
       teamID: process.env.APPLE_OAUTH_TEAM_ID,
       keyID: process.env.APPLE_OAUTH_KEY_ID,
-      callbackURL: process.env.APPLE_OAUTH_CALLBACK_URL,
+      // callbackURL: process.env.APPLE_OAUTH_CALLBACK_URL,
       keyFilePath: process.env.APPLE_OAUTH_PRIVATE_KEY_PATH,
       scope: ['email', 'name'],
+    });
+  }
+
+  authenticate(req: Request, options?: any) {
+    const platform = parseQueries(req.url)?.platform || 'web';
+    console.log('apple authenticate', req.url, 'platform', platform);
+    super.authenticate(req, {
+      ...options,
+      callbackURL: `${process.env.GOOGLE_OAUTH_CALLBACK_URI}?platform=${platform}`, // authenticate 오버라이딩으로 동적 Url 적용
     });
   }
 }

--- a/src/domain/auth/strategy/google.stratagy.ts
+++ b/src/domain/auth/strategy/google.stratagy.ts
@@ -1,7 +1,9 @@
 import { PassportStrategy } from '@nestjs/passport';
-import { Strategy, VerifyCallback } from 'passport-google-oauth20';
 import { Injectable } from '@nestjs/common';
 import { ParsedGoogltAuthProfileType } from '../dto/google-auth.dto';
+import { Strategy, VerifyCallback } from 'passport-google-oauth20';
+import { Request } from 'express';
+import { parseQueries } from 'src/libs/utils/helper/parseQuery';
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
@@ -9,10 +11,20 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     super({
       clientID: process.env.GOOGLE_OAUTH_CLIENT_ID,
       clientSecret: process.env.GOOGLE_OAUTH_SECRET_KEY,
-      callbackURL: process.env.GOOGLE_OAUTH_CALLBACK_URI,
+      // callbackURL: process.env.GOOGLE_OAUTH_CALLBACK_URI, //옵션에 넣지 않아서 디폴트 적용 해제
       scope: ['email', 'profile'],
     });
   }
+
+  authenticate(req: Request, options?: any) {
+    const platform = parseQueries(req.url)?.platform || 'web';
+    console.log('authenticate', req.url, 'platform', platform);
+    super.authenticate(req, {
+      ...options,
+      callbackURL: `${process.env.GOOGLE_OAUTH_CALLBACK_URI}?platform=${platform}`, // authenticate 오버라이딩으로 동적 Url 적용
+    });
+  }
+
   async validate(
     accessToken: string,
     refreshToken: string,

--- a/src/libs/utils/helper/parseQuery.ts
+++ b/src/libs/utils/helper/parseQuery.ts
@@ -1,0 +1,12 @@
+export const parseQueries = (url: string) => {
+  const params = {} as { [key: string]: string };
+  const queryString = url.split('?')[1];
+  if (queryString) {
+    const keyValuePairs = queryString.split('&');
+    keyValuePairs.forEach((pair) => {
+      const [key, value] = pair.split('=');
+      params[decodeURIComponent(key)] = decodeURIComponent(value || '');
+    });
+  }
+  return params;
+};

--- a/src/module/image-processing/image-processing.module.ts
+++ b/src/module/image-processing/image-processing.module.ts
@@ -2,12 +2,10 @@ import { Logger, Module } from '@nestjs/common';
 import { ImageProcessingService } from './image-processing.service';
 import { SharpModule } from './sharp/sharp.module';
 import { HttpModule } from '@nestjs/axios';
-import { ImageProcessingController } from './image-processing.controller';
 import { AwsS3Module } from '../aws-s3/aws-s3.module';
 
 @Module({
   imports: [AwsS3Module, SharpModule, HttpModule],
-  controllers: [ImageProcessingController],
   providers: [ImageProcessingService, Logger],
   exports: [ImageProcessingService, SharpModule],
 })


### PR DESCRIPTION
## Motivation

- 모바일, 웹 환경에서 엑세스토큰 및 리프레시토큰 전달 방식을 다르게 하여, 웹상에서 로그인과 웹뷰상에서 로그인을 다르게 할 수 있도록 기능을 구현하였습니다.

- Passport의 Strategy 과정에서 접속한 플랫폼의 종류를 확인하고, 해당 플랫폼에 맞게 적절한 url로 리다이렉트 합니다.

### 프로세스 과정
  1. 웹, 또는 웹뷰에서 `/api/auth/login/google?platform=mobile`와 같이 url의 쿼리로 user-Agent의 **플랫폼 정보를 서버에 전달**합니다.
  2. 인증 과정 완료 후 callback으로 엑세스토큰을 전달받을 때 user-Agent의 플랫폼 정보를 알아야하므로, Google 및 apple Strategy 안의 **authenticate를 오버라이딩하여 플랫폼 정보를 전달받을수 있도록 설정합니다.**

  - **google Strategy의 경우,** gcp에서 callBackUrl을 여러 개 설정할 수 있어서 **callbackUrl을 동적으로 설정**합니다.
     authenticate 메서드 안에서 플랫폼에 맞는 callBackUrl을 options로 전달합니다. 
   
    <details>
    <summary> gcp에 등록된 callBack Url, Startegy 코드 확인 </summary>
    <img width="609" alt="image" src="https://github.com/Hipspot/hipspot-backEnd_Node/assets/66112027/2277452c-53f7-478d-90f9-923885cf121e">

     <img width="928" alt="image" src="https://github.com/Hipspot/hipspot-backEnd_Node/assets/66112027/22c50a38-de5d-4c8f-80c1-1a755ea17ec6">
</details>

   -  'passport-google-oauth20' 라이브러리에서는 따로 authentificate 메서드를 구현해놓지 않았고, passport-oauth2 메서드를 상속받아 실행합니다. passport-oauth2 라이브러리에서 authtificate 메서드를 실행할때 options로 받는 값을 오버라이드 하므로, options에 callBackUrl 프로퍼티를 추가해서 실행합니다.       
    <details>
    <summary> node_modules/passport_oauth2/lib/strategy.js  </summary> 
    <img width="848" alt="image" src="https://github.com/Hipspot/hipspot-backEnd_Node/assets/66112027/8b74dbee-22b5-4429-a013-2663e671de2f">
</details>

  - **apple Strategy의 경우**, 하나의 callBackUrl만 설정할 수 있으므로, url을 바꾸는게 아닌 **state를 추가하고**, callBackUrl에서 해당 **state를 파싱해서 사용**합니다.
 
    <details>
    <summary>  Apple Strategy 코드 확인  </summary> 

    <img width="560" alt="image" src="https://github.com/Hipspot/hipspot-backEnd_Node/assets/66112027/a6f6c483-6a32-420f-a92c-1a87c8d98645">
    </details>

  - '@arendajaelu/nestjs-passport-apple' 라이브러리에서, options에 state 값을 전달하면 callBackUrl에 쿼리로 state를 추가해주는 과정이 있습니다.   
    <details>
    <summary>  node_modules/.pnpm/@arendajaelu+nestjs-passport-apple@1.0.4/node_modules/@arendajaelu/nestjs-passport-apple/src/strategy.js  </summary>  

    <img width="712" alt="image" src="https://github.com/Hipspot/hipspot-backEnd_Node/assets/66112027/78f6b413-6077-469f-bca7-153a3fca9955">
    </details>

  3. auth/callback 으로 전달받은 accessToken을 클라이언트에게 리다이렉트합니다.
    - 모바일의 경우 hipspot-mobile://?access_token=...&refresh_token=... 으로 location을 이동해주는 HTML 텍스트를 전달합니다.
    - 웹의 경우 미리 /redirect?access_token=... 으로 엑세스토큰을 전달하고, 쿠키에 refresh 토큰을 설정해줍니다.

## To Reviewers
사실 애플 로그인 같은 경우, 웹뷰가 아니라 네이티브 환경에서 로그인 하는 기능이 있습니다. 앱스토어 통과 안되면 그거 구현해야할거같아요...