### PR TITLE
HOTFIX: 리프레시토큰 유효성 확인 코드 추가

### DIFF
--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import { AuthService } from './auth.service';
 import { ParsedGoogltAuthProfileType } from './dto/google-auth.dto';
 import { AppleAuthGuard } from './guard/apple-auth-guard';
 import { GoogleAuthGuard } from './guard/google-auth-guard';
+import { JWTException, JwtStatus } from 'src/global/exception/jwt.exception';
 
 @Controller('auth')
 export class AuthController {
@@ -256,9 +257,15 @@ export class AuthController {
     if (!hipspot_refresh_token) return res.redirect('/auth/login/google');
 
     /**
-     * 1. 리프레시 토큰 디코딩. 유저 확인
+     * 1. 리프레시 토큰 유효 확인 이후 토큰 디코딩
      */
     this.logger.log('리프레시 토큰 확인', hipspot_refresh_token);
+
+    try {
+      this.jwtService.verify(hipspot_refresh_token);
+    } catch (e) {
+      throw new HttpException('리프레시토큰 잘못됨', HttpStatus.UNAUTHORIZED);
+    }
 
     const { userId, crypto } = this.jwtService.decode(
       hipspot_refresh_token,
@@ -272,7 +279,11 @@ export class AuthController {
 
     /**
      * 2. 리프레시토큰 유효성 검사 이후, 액세스토큰 재발급 또는 리프레시토큰 재발급
+<<<<<<< Updated upstream
      *
+=======
+     * //ㄷㅌ
+>>>>>>> Stashed changes
      */
     try {
       if (await this.authService.refreshTokenValidate(user, crypto)) {


### PR DESCRIPTION
## Motivation
#28 

- auth/reissuence에서 jwtSevice.verify() 수행
