### PR TITLE
Bug: 오타로 인한 가성비 마커 가격 오류 #31

### DIFF
--- a/src/domain/map/schemas/Geojson.schemas.ts
+++ b/src/domain/map/schemas/Geojson.schemas.ts
@@ -26,7 +26,7 @@ export class Geojson extends Document {
     cafeName: string;
     filterList: number[];
     thumbNail: string;
-    resonablePrice: number | null;
+    reasonablePrice: number | null;
   };
 }
 


### PR DESCRIPTION
## Motivation
close #31 
- 오타 수정했습니다

<br>

## Key Changes

- map domain의 scheme 중 cafe.properties의 resonablePrice -> reasonablePrice

